### PR TITLE
Convert all unit test cases from tap to node:test

### DIFF
--- a/test/archiver.test.js
+++ b/test/archiver.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const tap = require('tap')
+const { test, mock } = require('node:test')
+const assert = require('assert')
 
 const setup = ({ isDirectory }) => {
-  const archiverModule = tap.mock('../src/utils/archiver.js', {
+  const archiverModule = mock('../src/utils/archiver.js', {
     'fs/promises': {
       lstat: async () => ({
         isDirectory: () => isDirectory,
@@ -25,8 +26,8 @@ const setup = ({ isDirectory }) => {
   return { archiverModule }
 }
 
-tap.test('throws an error if path not found', async t => {
-  const archiverModule = tap.mock('../src/utils/archiver.js', {
+test('throws an error if path not found', async () => {
+  const archiverModule = mock('../src/utils/archiver.js', {
     'fs/promises': {
       lstat: async () => ({
         isDirectory: () => {
@@ -36,17 +37,17 @@ tap.test('throws an error if path not found', async t => {
     },
   })
 
-  await t.rejects(archiverModule.archiveItem('path', 'out.zip'))
+  await assert.rejects(archiverModule.archiveItem('path', 'out.zip'))
 })
 
-tap.test('does not throw any errors if directory', async t => {
+test('does not throw any errors if directory', async () => {
   const { archiverModule } = setup({ isDirectory: true })
 
-  await t.resolves(archiverModule.archiveItem('path', 'out.zip'))
+  await assert.doesNotReject(archiverModule.archiveItem('path', 'out.zip'))
 })
 
-tap.test('throws if writing to zip file fails', async t => {
-  const archiverModule = tap.mock('../src/utils/archiver.js', {
+test('throws if writing to zip file fails', async () => {
+  const archiverModule = mock('../src/utils/archiver.js', {
     'fs/promises': {
       lstat: async () => ({
         isDirectory: () => true,
@@ -65,11 +66,11 @@ tap.test('throws if writing to zip file fails', async t => {
     },
   })
 
-  await t.rejects(archiverModule.archiveItem('path', 'out.zip'))
+  await assert.rejects(archiverModule.archiveItem('path', 'out.zip'))
 })
 
-tap.test('resolves if a path is not a directory', async t => {
-  const archiverModule = tap.mock('../src/utils/archiver.js', {
+test('resolves if a path is not a directory', async () => {
+  const archiverModule = mock('../src/utils/archiver.js', {
     'fs/promises': {
       lstat: async () => ({
         isDirectory: () => false,
@@ -88,11 +89,11 @@ tap.test('resolves if a path is not a directory', async t => {
     },
   })
 
-  await t.resolves(archiverModule.archiveItem('path', 'out.zip'))
+  await assert.doesNotReject(archiverModule.archiveItem('path', 'out.zip'))
 })
 
-tap.test('does not throw any errors if file', async t => {
+test('does not throw any errors if file', async () => {
   const { archiverModule } = setup({ isDirectory: false })
 
-  await t.resolves(archiverModule.archiveItem('file.js', 'out.zip'))
+  await assert.doesNotReject(archiverModule.archiveItem('file.js', 'out.zip'))
 })

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test, mock } = require('node:test')
 const { ZIP_EXTENSION } = require('../src/const')
 
 const DEFAULT_INPUT_DATA = {
@@ -10,7 +10,7 @@ const DEFAULT_INPUT_DATA = {
 }
 
 const setup = ({ throwsError }) => {
-  const attachArtifactModule = tap.mock('../src/utils/artifact.js', {
+  const attachArtifactModule = mock('../src/utils/artifact.js', {
     '../src/utils/archiver.js': {
       archiveItem: async () => null,
     },
@@ -47,27 +47,27 @@ const setup = ({ throwsError }) => {
   return { attachArtifactModule }
 }
 
-tap.test(
+test(
   'attach artifact does not throw errors with proper inputs',
-  async t => {
+  async () => {
     const { attachArtifactModule } = setup({ throwsError: false })
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    await t.resolves(
+    await assert.doesNotReject(
       attachArtifactModule.attach(artifactPath, releaseId, token)
     )
   }
 )
 
-tap.test(
+test(
   'attach artifact does not throw errors with path ending with .zip',
-  async t => {
+  async () => {
     const { attachArtifactModule } = setup({ throwsError: false })
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    await t.resolves(
+    await assert.doesNotReject(
       attachArtifactModule.attach(
         artifactPath + ZIP_EXTENSION,
         releaseId,
@@ -77,10 +77,10 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'attach artifact throws an error if build folder not found',
-  async t => {
-    const artifactModule = tap.mock('../src/utils/artifact.js', {
+  async () => {
+    const artifactModule = mock('../src/utils/artifact.js', {
       '../src/utils/archiver.js': {
         archiveItem: async () => {
           throw new Error('file not found')
@@ -90,25 +90,25 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    await t.rejects(artifactModule.attach(artifactPath, releaseId, token))
+    await assert.rejects(artifactModule.attach(artifactPath, releaseId, token))
   }
 )
 
-tap.test(
+test(
   'attach artifact throws an error if an error occurres during the asset upload',
-  async t => {
+  async () => {
     const { attachArtifactModule } = setup({ throwsError: true })
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    await t.rejects(attachArtifactModule.attach(artifactPath, releaseId, token))
+    await assert.rejects(attachArtifactModule.attach(artifactPath, releaseId, token))
   }
 )
 
-tap.test(
+test(
   'attach artifact throws an error if the upload asset state is not uploaded',
-  async t => {
-    const artifactModule = tap.mock('../src/utils/artifact.js', {
+  async () => {
+    const artifactModule = mock('../src/utils/artifact.js', {
       '../src/utils/archiver.js': {
         archiveItem: async () => null,
       },
@@ -139,6 +139,6 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    await t.rejects(artifactModule.attach(artifactPath, releaseId, token))
+    await assert.rejects(artifactModule.attach(artifactPath, releaseId, token))
   }
 )

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const core = require('@actions/core')
@@ -90,7 +90,7 @@ function setup() {
   }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
@@ -119,7 +119,7 @@ const DEFAULT_ACTION_DATA = {
   },
 }
 
-tap.test(
+test(
   'should trigger an error when the packageVersion is missing',
   async t => {
     const { openPr } = setup()
@@ -134,7 +134,7 @@ tap.test(
   }
 )
 
-tap.test('should trigger an error if the branch already exists', async t => {
+test('should trigger an error if the branch already exists', async t => {
   const { openPr, stubs } = setup()
 
   const actionData = {
@@ -152,7 +152,7 @@ tap.test('should trigger an error if the branch already exists', async t => {
   )
 })
 
-tap.test('should create a new git branch', async () => {
+test('should create a new git branch', async () => {
   const { openPr, stubs } = setup()
   await openPr(DEFAULT_ACTION_DATA)
 
@@ -176,7 +176,7 @@ tap.test('should create a new git branch', async () => {
   ])
 })
 
-tap.test('should handle custom commit messages', async () => {
+test('should handle custom commit messages', async () => {
   const { openPr, stubs } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.inputs['commit-message'] =
@@ -202,7 +202,7 @@ tap.test('should handle custom commit messages', async () => {
   ])
 })
 
-tap.test('should work with a custom version-prefix', async () => {
+test('should work with a custom version-prefix', async () => {
   const { openPr, stubs } = setup()
 
   const prData = {
@@ -266,7 +266,7 @@ tap.test('should work with a custom version-prefix', async () => {
   })
 })
 
-tap.test('should call the release endpoint with a new version', async () => {
+test('should call the release endpoint with a new version', async () => {
   const { openPr, stubs } = setup()
   await openPr(DEFAULT_ACTION_DATA)
 
@@ -286,7 +286,7 @@ tap.test('should call the release endpoint with a new version', async () => {
   )
 })
 
-tap.test(
+test(
   'should trigger an error if the release endpoint responds with an invalid draft release',
   async t => {
     const { openPr, stubs } = setup()
@@ -300,7 +300,7 @@ tap.test(
   }
 )
 
-tap.test('should call the PR endpoint with a new version', async () => {
+test('should call the PR endpoint with a new version', async () => {
   const { openPr, stubs } = setup()
   await openPr(DEFAULT_ACTION_DATA)
 
@@ -350,7 +350,7 @@ tap.test('should call the PR endpoint with a new version', async () => {
   )
 })
 
-tap.test(
+test(
   'should create the correct release for a version with no minor',
   async () => {
     const localVersion = '2.0.0'
@@ -408,7 +408,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'should create the correct release for a version with no major',
   async () => {
     const localVersion = '0.0.5'
@@ -466,7 +466,7 @@ tap.test(
   }
 )
 
-tap.test('should delete branch in case of pr failure', async t => {
+test('should delete branch in case of pr failure', async t => {
   const localVersion = '0.0.5'
   const { openPr, stubs } = setup()
   const { context, inputs } = DEFAULT_ACTION_DATA
@@ -485,7 +485,7 @@ tap.test('should delete branch in case of pr failure', async t => {
   t.pass('branch deleted')
 })
 
-tap.test('Should call core.setFailed if it fails to create a PR', async t => {
+test('Should call core.setFailed if it fails to create a PR', async t => {
   const branchName = `release/v${TEST_VERSION}`
 
   const { openPr, stubs } = setup()
@@ -502,7 +502,7 @@ tap.test('Should call core.setFailed if it fails to create a PR', async t => {
   t.pass('failed called')
 })
 
-tap.test(
+test(
   'should call attachArtifact if artifact-path input is present',
   async () => {
     const { openPr, stubs } = setup()
@@ -514,7 +514,7 @@ tap.test(
   }
 )
 
-tap.test('should not open Pr if create release draft fails', async t => {
+test('should not open Pr if create release draft fails', async t => {
   const { openPr, stubs } = setup()
   stubs.callApiStub.throws({ message: 'error message' })
 
@@ -524,7 +524,7 @@ tap.test('should not open Pr if create release draft fails', async t => {
   )
 })
 
-tap.test(
+test(
   'should generate release notes if the latest release has not been found -> first release',
   async () => {
     const { openPr, stubs } = setup()
@@ -549,7 +549,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'should automatically generate release notes if an error occurred while generating the specific release notes',
   async () => {
     const { openPr, stubs } = setup()
@@ -576,7 +576,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'should retrieve the specified base-tag release and POST a release with the generated release notes',
   async () => {
     const { openPr, stubs } = setup()

--- a/test/callApi.test.js
+++ b/test/callApi.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const actionLog = require('../src/log')
@@ -20,11 +20,11 @@ const setup = status => {
   return { logStub, callApiProxy, fetchStub }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Call api warns if code is not 200', async () => {
+test('Call api warns if code is not 200', async () => {
   const { logStub, callApiProxy } = setup(401)
   await callApiProxy.callApi(
     {
@@ -39,7 +39,7 @@ tap.test('Call api warns if code is not 200', async () => {
   sinon.assert.calledOnce(logStub.logWarning)
 })
 
-tap.test('Call api does not warn if code is  200', async () => {
+test('Call api does not warn if code is  200', async () => {
   const { logStub, callApiProxy } = setup(200)
   await callApiProxy.callApi(
     {
@@ -52,7 +52,7 @@ tap.test('Call api does not warn if code is  200', async () => {
   sinon.assert.notCalled(logStub.logWarning)
 })
 
-tap.test('Call api does not append slash to api url if present', async () => {
+test('Call api does not append slash to api url if present', async () => {
   const { fetchStub, callApiProxy } = setup(200)
   await callApiProxy.callApi(
     {
@@ -65,7 +65,7 @@ tap.test('Call api does not append slash to api url if present', async () => {
   sinon.assert.calledWith(fetchStub, 'whatever/release')
 })
 
-tap.test('Call api appends slash to api url if not present', async () => {
+test('Call api appends slash to api url if not present', async () => {
   const { fetchStub, callApiProxy } = setup(200)
   await callApiProxy.callApi(
     {

--- a/test/commitMessage.test.js
+++ b/test/commitMessage.test.js
@@ -1,17 +1,18 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
+const assert = require('assert')
 const transformCommitMessage = require('../src/utils/commitMessage')
 
-tap.test('Handles normal commit messages', async t => {
-  t.equal(
+test('Handles normal commit messages', async () => {
+  assert.strictEqual(
     'Release v5.1.0',
     transformCommitMessage('Release {version}', 'v5.1.0')
   )
 })
 
-tap.test('Handles customized messages', async t => {
-  t.equal(
+test('Handles customized messages', async () => {
+  assert.strictEqual(
     '[v5.1.0] Released! Some long text goes here!',
     transformCommitMessage(
       '[{version}] Released! Some long text goes here!',
@@ -20,8 +21,8 @@ tap.test('Handles customized messages', async t => {
   )
 })
 
-tap.test('Handles messages with quotes', async t => {
-  t.equal(
+test('Handles messages with quotes', async () => {
+  assert.strictEqual(
     '[v5.1.0] \\"Quotes\\"',
     transformCommitMessage('[{version}] "Quotes"', 'v5.1.0')
   )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire').noCallThru()
 const sinon = require('sinon')
 
@@ -51,7 +51,7 @@ function buildStubbedAction() {
   }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
@@ -74,7 +74,7 @@ const DEFAULT_ACTION_DATA = {
   },
 }
 
-tap.test(
+test(
   'should not run if the event is not workflow_dispatch or pull_request',
   async () => {
     const { action, stubs } = buildStubbedAction()
@@ -90,7 +90,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   "the release feature should be called if it's a pull request",
   async () => {
     const { action, stubs } = buildStubbedAction()
@@ -107,7 +107,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   "the bump feature should be called if it's a workflow_dispatch",
   async () => {
     const { action, stubs } = buildStubbedAction()
@@ -124,7 +124,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'npm should be configured if called with npm-token in inputs',
   async () => {
     const { action, stubs } = buildStubbedAction()
@@ -144,7 +144,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'semver-auto: should call getAutoBumpedVersion if semver is auto',
   async t => {
     const { bumpVersion, stubs } = buildStubbedAction()
@@ -169,7 +169,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'semver-auto: should not call getAutoBumpedVersion if semver is not auto',
   async t => {
     const { bumpVersion, stubs } = buildStubbedAction()
@@ -187,7 +187,7 @@ tap.test(
   }
 )
 
-tap.test('semver-auto: should bump major if breaking change', async t => {
+test('semver-auto: should bump major if breaking change', async t => {
   const { bumpVersion, stubs } = buildStubbedAction()
 
   stubs.bumpStub.resolves({ releaseType: 'major' })
@@ -209,7 +209,7 @@ tap.test('semver-auto: should bump major if breaking change', async t => {
   t.same(newVersion, '3.0.0')
 })
 
-tap.test('semver-auto: should bump minor if its a feat', async t => {
+test('semver-auto: should bump minor if its a feat', async t => {
   const { bumpVersion, stubs } = buildStubbedAction()
 
   stubs.bumpStub.resolves({ releaseType: 'minor' })
@@ -231,7 +231,7 @@ tap.test('semver-auto: should bump minor if its a feat', async t => {
   t.same(newVersion, '3.0.0')
 })
 
-tap.test('semver-auto: should bump patch if its a fix', async t => {
+test('semver-auto: should bump patch if its a fix', async t => {
   const { bumpVersion, stubs } = buildStubbedAction()
 
   stubs.bumpStub.resolves({ releaseType: 'patch' })
@@ -253,7 +253,7 @@ tap.test('semver-auto: should bump patch if its a fix', async t => {
   t.same(newVersion, '3.0.0')
 })
 
-tap.test(
+test(
   'semver-auto: should use the correct base tag if specified',
   async t => {
     const { bumpVersion, stubs } = buildStubbedAction()
@@ -282,7 +282,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'semver-auto: should get the latest tag if base tag not provided',
   async t => {
     const { bumpVersion, stubs } = buildStubbedAction()
@@ -312,7 +312,7 @@ tap.test(
   }
 )
 
-tap.test('semver-auto: should throw if auto bump fails', async t => {
+test('semver-auto: should throw if auto bump fails', async t => {
   const { bumpVersion, stubs } = buildStubbedAction()
 
   stubs.bumpStub.throws(new Error('bump failed'))
@@ -329,7 +329,7 @@ tap.test('semver-auto: should throw if auto bump fails', async t => {
   }
 })
 
-tap.test('semver-auto: should default to patch if auto bump fails', async t => {
+test('semver-auto: should default to patch if auto bump fails', async t => {
   const { bumpVersion, stubs } = buildStubbedAction()
 
   stubs.bumpStub.resolves({})

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const core = require('@actions/core')
@@ -14,31 +14,31 @@ const setup = () => {
   return { coreStub, logger }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('calling log with an array will stringify it', async () => {
+test('calling log with an array will stringify it', async () => {
   const { logger, coreStub } = setup()
   logger.logDebug([1, 2, 3])
   sinon.assert.calledWithExactly(coreStub.debug, '1,2,3')
 })
 
-tap.test('logDebug calls @actions/core/debug', async () => {
+test('logDebug calls @actions/core/debug', async () => {
   const { logger, coreStub } = setup()
   logger.logDebug('Debug')
   sinon.assert.calledOnce(coreStub.debug)
   sinon.assert.notCalled(coreStub.error)
 })
 
-tap.test('logError calls @actions/core/error', async () => {
+test('logError calls @actions/core/error', async () => {
   const { logger, coreStub } = setup()
   logger.logError(new Error('not a string'))
   sinon.assert.calledOnce(coreStub.error)
   sinon.assert.notCalled(coreStub.debug)
 })
 
-tap.test('logInfo calls @actions/core/info', async () => {
+test('logInfo calls @actions/core/info', async () => {
   const { logger, coreStub } = setup()
   logger.logInfo('Debug')
 
@@ -46,7 +46,7 @@ tap.test('logInfo calls @actions/core/info', async () => {
   sinon.assert.notCalled(coreStub.debug)
 })
 
-tap.test('logWarning calls @actions/core/warning', async () => {
+test('logWarning calls @actions/core/warning', async () => {
   const { logger, coreStub } = setup()
   logger.logWarning('warning')
 

--- a/test/ngrokOtpVerification.test.js
+++ b/test/ngrokOtpVerification.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -42,11 +42,11 @@ const setup = () => {
   }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Should successfully verify OTP', async t => {
+test('Should successfully verify OTP', async t => {
   const { ngrokOtpVerificationProxy, mockApp } = setup()
 
   // Capture the OTP callback
@@ -78,7 +78,7 @@ tap.test('Should successfully verify OTP', async t => {
   t.equal(otp, '123456', 'should return submitted OTP')
 })
 
-tap.test('Should timeout after 5 minutes', async t => {
+test('Should timeout after 5 minutes', async t => {
   const { ngrokOtpVerificationProxy, logErrorStub } = setup()
 
   // Use fake timers
@@ -104,7 +104,7 @@ tap.test('Should timeout after 5 minutes', async t => {
   }
 })
 
-tap.test('Should handle HTML template rendering', async t => {
+test('Should handle HTML template rendering', async t => {
   const { ngrokOtpVerificationProxy, mockApp } = setup()
 
   let renderedHtml
@@ -147,7 +147,7 @@ tap.test('Should handle HTML template rendering', async t => {
   t.match(renderedHtml, /v1.0.0/, 'should include package version')
 })
 
-tap.test(
+test(
   'Should handle the failure case when fastify app or html fails to load',
   async t => {
     const { ngrokOtpVerificationProxy, mockApp } = setup()

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const tap = require('tap')
 
 const pullsGetStub = sinon.stub()
 const createCommentStub = sinon.stub()
@@ -37,11 +37,11 @@ function setup() {
   return { notifyIssues }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Should not call createComment if no linked issues', async () => {
+test('Should not call createComment if no linked issues', async () => {
   const { notifyIssues } = setup()
 
   const releaseNotes = `
@@ -61,7 +61,7 @@ tap.test('Should not call createComment if no linked issues', async () => {
   sinon.assert.notCalled(createCommentStub)
 })
 
-tap.test(
+test(
   'Should not call createComment if linked issue belongs to external repo',
   async () => {
     const { notifyIssues } = setup()
@@ -106,7 +106,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should call createComment with correct arguments for linked issues with npm link',
   async () => {
     const { notifyIssues } = setup()
@@ -180,7 +180,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should call createComment with correct arguments for linked issues without npm link',
   async () => {
     const { notifyIssues } = setup()
@@ -253,7 +253,7 @@ tap.test(
   }
 )
 
-tap.test("Shouldn't fail if createComment on an issue fails", async t => {
+test("Shouldn't fail if createComment on an issue fails", async t => {
   const { notifyIssues } = setup()
 
   const releaseNotes = `

--- a/test/packageInfo.test.js
+++ b/test/packageInfo.test.js
@@ -1,5 +1,6 @@
 'use strict'
-const tap = require('tap')
+const { test } = require('node:test')
+const assert = require('assert')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -43,75 +44,75 @@ const setupLocal = ({ value = JSON.stringify(mockPackageInfo) } = {}) => {
   })
 }
 
-tap.test('getPublishedInfo does not get any info for this package', async t => {
+test('getPublishedInfo does not get any info for this package', async () => {
   // Check it works for real: this package is a Github Action, not published on NPM, so expect null
   const packageInfo = await getPublishedInfo()
-  t.notOk(packageInfo)
+  assert.strictEqual(packageInfo, null)
 })
 
-tap.test('getPublishedInfo parses any valid JSON it finds', async t => {
+test('getPublishedInfo parses any valid JSON it finds', async () => {
   const mocks = setupPublished()
 
   const packageInfo = await mocks.getPublishedInfo()
-  t.match(packageInfo, mockPackageInfo)
+  assert.deepStrictEqual(packageInfo, mockPackageInfo)
 })
 
-tap.test(
+test(
   'getPublishedInfo continues and returns null if the request 404s',
-  async t => {
+  async () => {
     const mocks = setupPublished({
       value: JSON.stringify(mockPackageInfo),
       error: new Error('code E404 - package not found'),
     })
 
     const packageInfo = await mocks.getPublishedInfo()
-    t.match(packageInfo, null)
+    assert.strictEqual(packageInfo, null)
   }
 )
 
-tap.test(
+test(
   'getPublishedInfo throws if it encounters an internal error',
-  async t => {
+  async () => {
     const mocks = setupPublished({
       value: "[{ 'this:' is not ] valid}j.s.o.n()",
     })
 
-    await t.rejects(mocks.getPublishedInfo, /JSON/)
+    await assert.rejects(mocks.getPublishedInfo, /JSON/)
   }
 )
 
-tap.test(
+test(
   'getPublishedInfo continues and returns null if the request returns null',
-  async t => {
+  async () => {
     const mocks = setupPublished({
       value: null,
     })
 
     const packageInfo = await mocks.getPublishedInfo()
-    t.match(packageInfo, null)
+    assert.strictEqual(packageInfo, null)
   }
 )
 
-tap.test('getPublishedInfo throws if it hits a non-404 error', async t => {
+test('getPublishedInfo throws if it hits a non-404 error', async () => {
   const mocks = setupPublished({
     error: new Error('code E418 - unexpected teapot'),
   })
 
-  await t.rejects(mocks.getPublishedInfo, /teapot/)
+  await assert.rejects(mocks.getPublishedInfo, /teapot/)
 })
 
-tap.test(
+test(
   'getLocalInfo gets real name and stable properties of this package',
-  async t => {
+  async () => {
     const packageInfo = getLocalInfo()
     // Check it works for real using real package.json properties that are stable
-    t.equal(packageInfo.name, 'optic-release-automation-action')
-    t.equal(packageInfo.license, 'MIT')
+    assert.strictEqual(packageInfo.name, 'optic-release-automation-action')
+    assert.strictEqual(packageInfo.license, 'MIT')
   }
 )
 
-tap.test('getLocalInfo gets data from stringified JSON from file', async t => {
+test('getLocalInfo gets data from stringified JSON from file', async () => {
   const mocks = setupLocal()
   const packageInfo = mocks.getLocalInfo()
-  t.match(packageInfo, mockPackageInfo)
+  assert.deepStrictEqual(packageInfo, mockPackageInfo)
 })

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const semver = require('semver')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
@@ -14,11 +14,11 @@ const {
 
 const MINIMUM_VERSION = '9.5.0'
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('getNpmVersion can get a real NPM version number', async t => {
+test('getNpmVersion can get a real NPM version number', async t => {
   const npmVersion = await getNpmVersion()
 
   t.type(npmVersion, 'string')
@@ -27,47 +27,47 @@ tap.test('getNpmVersion can get a real NPM version number', async t => {
   t.ok(semver.satisfies(npmVersion, '>0.0.1'))
 })
 
-tap.test('checkIsSupported passes on minimum NPM version', async t => {
+test('checkIsSupported passes on minimum NPM version', async t => {
   t.doesNotThrow(() => checkIsSupported(MINIMUM_VERSION))
 })
 
-tap.test('checkIsSupported passes on major version after minimum', async t => {
+test('checkIsSupported passes on major version after minimum', async t => {
   t.doesNotThrow(() => checkIsSupported('10.0.0'))
 })
 
-tap.test('checkIsSupported fails on minor version before minimum', async t => {
+test('checkIsSupported fails on minor version before minimum', async t => {
   t.throws(
     () => checkIsSupported('9.4.0'),
     `Provenance requires NPM ${MINIMUM_VERSION}`
   )
 })
 
-tap.test('checkIsSupported fails on major version before minimum', async t => {
+test('checkIsSupported fails on major version before minimum', async t => {
   t.throws(
     () => checkIsSupported('8.0.0'),
     `Provenance requires NPM ${MINIMUM_VERSION}`
   )
 })
 
-tap.test('checkPermissions always passes on NPM 9.6.1', async t => {
+test('checkPermissions always passes on NPM 9.6.1', async t => {
   t.doesNotThrow(() => checkIsSupported('9.6.1'))
 })
 
-tap.test(
+test(
   'checkPermissions always passes on next major NPM version',
   async t => {
     t.doesNotThrow(() => checkIsSupported('10.0.0'))
   }
 )
 
-tap.test('checkPermissions fails on minimum version without env', async t => {
+test('checkPermissions fails on minimum version without env', async t => {
   t.throws(
     () => checkPermissions(MINIMUM_VERSION),
     'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
   )
 })
 
-tap.test('checkPermissions passes on minimum version with env', async t => {
+test('checkPermissions passes on minimum version with env', async t => {
   sinon
     .stub(process, 'env')
     .value({ ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' })
@@ -87,7 +87,7 @@ const setupAccessAdjustment = ({ local, published }) => {
 const unscopedPackageName = 'unscoped-fake-package'
 const scopedPackageName = '@scoped/fake-package'
 
-tap.test(
+test(
   'getAccessAdjustment returns { access: public } if unscoped, unpublished and no access option',
   async t => {
     const getAccessAdjustment = setupAccessAdjustment({
@@ -98,7 +98,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'getAccessAdjustment does nothing if passed defined access option',
   async t => {
     const getAccessAdjustment = setupAccessAdjustment({
@@ -109,7 +109,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'getAccessAdjustment does nothing if package.json defines access',
   async t => {
     const getAccessAdjustment = setupAccessAdjustment({
@@ -123,7 +123,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'getAccessAdjustment does nothing if package.json name is scoped',
   async t => {
     const getAccessAdjustment = setupAccessAdjustment({
@@ -134,7 +134,7 @@ tap.test(
   }
 )
 
-tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
+test('getAccessAdjustment does nothing if package is on npm', async t => {
   const getAccessAdjustment = setupAccessAdjustment({
     local: { name: unscopedPackageName },
     published: { name: unscopedPackageName },
@@ -142,7 +142,7 @@ tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
   t.notOk(await getAccessAdjustment())
 })
 
-tap.test(
+test(
   'getProvenanceOptions fails fast if NPM version unavailable',
   async t => t.rejects(getProvenanceOptions, 'Current npm version not provided')
 )

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -65,11 +65,11 @@ const setup = ({
   }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Should publish to npm with optic', async t => {
+test('Should publish to npm with optic', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -84,13 +84,13 @@ tap.test('Should publish to npm with optic', async t => {
     'set',
     '//registry.npmjs.org/:_authToken=a-token',
   ])
-  t.pass('npm config')
+  assert.pass('npm config')
 
   sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'pack',
     '--dry-run',
   ])
-  t.pass('npm pack called')
+  assert.pass('npm pack called')
 
   sinon.assert.calledWithExactly(execWithOutputStub, 'curl', [
     '-s',
@@ -102,7 +102,7 @@ tap.test('Should publish to npm with optic', async t => {
     'POST',
     'https://optic-test.run.app/api/generate/optic-token',
   ])
-  t.pass('curl called')
+  assert.pass('curl called')
 
   sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'publish',
@@ -111,12 +111,12 @@ tap.test('Should publish to npm with optic', async t => {
     '--tag',
     'latest',
   ])
-  t.pass('npm publish called')
+  assert.pass('npm publish called')
 })
 
-tap.test(
+test(
   "Should publish to npm when package hasn't been published before",
-  async t => {
+  async () => {
     const { publishToNpmProxy, execWithOutputStub } = setup({
       published: false,
     })
@@ -132,18 +132,18 @@ tap.test(
       'pack',
       '--dry-run',
     ])
-    t.pass('npm pack called')
+    assert.pass('npm pack called')
 
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
-    t.pass('npm publish called')
+    assert.pass('npm publish called')
   }
 )
 
-tap.test('Should publish to npm without optic', async t => {
+test('Should publish to npm without optic', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -156,19 +156,19 @@ tap.test('Should publish to npm without optic', async t => {
     'pack',
     '--dry-run',
   ])
-  t.pass('npm pack called')
+  assert.pass('npm pack called')
 
   sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'publish',
     '--tag',
     'latest',
   ])
-  t.pass('npm publish called')
+  assert.pass('npm publish called')
 })
 
-tap.test(
+test(
   'Should skip npm package publication when it was already published',
-  async t => {
+  async () => {
     const { publishToNpmProxy, execWithOutputStub } = setup()
 
     execWithOutputStub
@@ -189,19 +189,19 @@ tap.test(
       '--tag',
       'latest',
     ])
-    t.pass('publish never called with otp')
+    assert.pass('publish never called with otp')
 
     sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
-    t.pass('publish never called')
+    assert.pass('publish never called')
   }
 )
 
-tap.test('Should stop action if package info retrieval fails', async t => {
-  t.plan(3)
+test('Should stop action if package info retrieval fails', async () => {
+  assert.plan(3)
   const { publishToNpmProxy, execWithOutputStub } = setup({
     // Use original getPublishedInfo logic with execWithOutputStub injected into it
     mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
@@ -223,7 +223,7 @@ tap.test('Should stop action if package info retrieval fails', async t => {
       version: 'v5.1.3',
     })
   } catch (e) {
-    t.equal(e.message, 'Network Error')
+    assert.equal(e.message, 'Network Error')
   }
 
   sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
@@ -233,20 +233,20 @@ tap.test('Should stop action if package info retrieval fails', async t => {
     '--tag',
     'latest',
   ])
-  t.pass('package is not published with otp code')
+  assert.pass('package is not published with otp code')
 
   sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
     'publish',
     '--tag',
     'latest',
   ])
-  t.pass('package is not published without otp code')
+  assert.pass('package is not published without otp code')
 })
 
-tap.test(
+test(
   'Should stop action if package version info retrieval fails',
-  async t => {
-    t.plan(3)
+  async () => {
+    assert.plan(3)
     const { publishToNpmProxy, execWithOutputStub } = setup()
 
     execWithOutputStub
@@ -261,7 +261,7 @@ tap.test(
         version: 'v5.1.3',
       })
     } catch (e) {
-      t.equal(e.message, 'Network Error')
+      assert.equal(e.message, 'Network Error')
     }
 
     sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
@@ -271,20 +271,20 @@ tap.test(
       '--tag',
       'latest',
     ])
-    t.pass('package is not published with otp code')
+    assert.pass('package is not published with otp code')
 
     sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
-    t.pass('package is not published without otp code')
+    assert.pass('package is not published without otp code')
   }
 )
 
-tap.test(
+test(
   'Should continue action if package info returns not found',
-  async t => {
+  async () => {
     const { publishToNpmProxy, execWithOutputStub } = setup({
       // Use original getPublishedInfo logic with execWithOutputStub injected into it
       mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
@@ -314,20 +314,20 @@ tap.test(
       'pack',
       '--dry-run',
     ])
-    t.pass('npm pack called')
+    assert.pass('npm pack called')
 
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
-    t.pass('npm publish called')
+    assert.pass('npm publish called')
   }
 )
 
-tap.test(
+test(
   'Should continue action if package version info returns not found',
-  async t => {
+  async () => {
     const { publishToNpmProxy, execWithOutputStub } = setup()
 
     execWithOutputStub
@@ -345,18 +345,18 @@ tap.test(
       'pack',
       '--dry-run',
     ])
-    t.pass('npm pack called')
+    assert.pass('npm pack called')
 
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
-    t.pass('npm publish called')
+    assert.pass('npm publish called')
   }
 )
 
-tap.test('Adds --provenance flag when provenance option provided', async () => {
+test('Adds --provenance flag when provenance option provided', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -374,7 +374,7 @@ tap.test('Adds --provenance flag when provenance option provided', async () => {
   ])
 })
 
-tap.test('Adds --access flag if provided as an input', async () => {
+test('Adds --access flag if provided as an input', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -393,7 +393,7 @@ tap.test('Adds --access flag if provided as an input', async () => {
   ])
 })
 
-tap.test('Should publish using ngrok for OTP verification', async t => {
+test('Should publish using ngrok for OTP verification', async () => {
   const { publishToNpmProxy, execWithOutputStub, otpVerificationStub } = setup({
     otpFlow: 'ngrok',
   })
@@ -418,10 +418,10 @@ tap.test('Should publish using ngrok for OTP verification', async t => {
     '--tag',
     'latest',
   ])
-  t.pass('npm publish called with ngrok OTP')
+  assert.pass('npm publish called with ngrok OTP')
 })
 
-tap.test('Should fail gracefully when ngrok services fail', async t => {
+test('Should fail gracefully when ngrok services fail', async () => {
   const { publishToNpmProxy, otpVerificationStub } = setup({
     mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
       getLocalInfo,
@@ -435,7 +435,7 @@ tap.test('Should fail gracefully when ngrok services fail', async t => {
   // Mock failed otpVerification
   otpVerificationStub.throws(new Error('Ngrok failed'))
 
-  await t.rejects(
+  await assert.rejects(
     publishToNpmProxy.publishToNpm({
       npmToken: 'a-token',
       ngrokToken: 'ngrok-token',
@@ -446,9 +446,9 @@ tap.test('Should fail gracefully when ngrok services fail', async t => {
   )
 })
 
-tap.test(
+test(
   'Should fail gracefully when fail to receive otp from optic',
-  async t => {
+  async () => {
     const { publishToNpmProxy, execWithOutputStub } = setup({
       otpFlow: 'optic',
     })
@@ -467,7 +467,7 @@ tap.test(
         'https://optic-test.run.app/api/generate/optic-token',
       ])
       .throws(new Error('Optic failed'))
-    await t.rejects(
+    await assert.rejects(
       publishToNpmProxy.publishToNpm({
         npmToken: 'a-token',
         opticToken: 'optic-token',

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const core = require('@actions/core')
@@ -133,11 +133,11 @@ function setup({ npmVersion, env, isPublished = true, isScoped = true } = {}) {
   }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Should delete the release if the pr is not merged', async () => {
+test('Should delete the release if the pr is not merged', async () => {
   const { release } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.context.payload.pull_request.merged = false
@@ -150,7 +150,7 @@ tap.test('Should delete the release if the pr is not merged', async () => {
   })
 })
 
-tap.test(
+test(
   'Should delete the release even if deleting the branch failed and should not fail',
   async () => {
     const { release, stubs } = setup()
@@ -171,7 +171,7 @@ tap.test(
   }
 )
 
-tap.test('Should log an error if deleting the release fails', async () => {
+test('Should log an error if deleting the release fails', async () => {
   const { release, stubs } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.context.payload.pull_request.merged = false
@@ -185,7 +185,7 @@ tap.test('Should log an error if deleting the release fails', async () => {
   )
 })
 
-tap.test(
+test(
   'Should log and exit if both the release and the branch fail',
   async () => {
     const { release, stubs } = setup()
@@ -206,7 +206,7 @@ tap.test(
   }
 )
 
-tap.test('Should publish to npm without optic', async () => {
+test('Should publish to npm without optic', async () => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -223,7 +223,7 @@ tap.test('Should publish to npm without optic', async () => {
   })
 })
 
-tap.test(
+test(
   'Should publish with provenance if flag set and conditions met',
   async t => {
     const { release, stubs } = setup({
@@ -252,7 +252,7 @@ tap.test(
   }
 )
 
-tap.test('Aborts publish with provenance if NPM version too old', async () => {
+test('Aborts publish with provenance if NPM version too old', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.4.0', // too old (is before 9.5.0)
     env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
@@ -273,7 +273,7 @@ tap.test('Aborts publish with provenance if NPM version too old', async () => {
   )
 })
 
-tap.test('Aborts publish with provenance if missing permission', async () => {
+test('Aborts publish with provenance if missing permission', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.5.0', // valid, but before missing var is correctly handled on NPM's side (9.6.1)
     // missing ACTIONS_ID_TOKEN_REQUEST_URL which is set from `id-token: write` permission.
@@ -294,7 +294,7 @@ tap.test('Aborts publish with provenance if missing permission', async () => {
   )
 })
 
-tap.test('Should publish with --access public if flag set', async t => {
+test('Should publish with --access public if flag set', async t => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -317,7 +317,7 @@ tap.test('Should publish with --access public if flag set', async t => {
   t.pass('called publishToNpm')
 })
 
-tap.test('Should publish with --access restricted if flag set', async t => {
+test('Should publish with --access restricted if flag set', async t => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -340,7 +340,7 @@ tap.test('Should publish with --access restricted if flag set', async t => {
   t.pass('called publishToNpm')
 })
 
-tap.test('Should disallow unsupported --access flag', async () => {
+test('Should disallow unsupported --access flag', async () => {
   const { release, stubs } = setup()
 
   const invalidString =
@@ -361,7 +361,7 @@ tap.test('Should disallow unsupported --access flag', async () => {
   )
 })
 
-tap.test(
+test(
   'Should publish with --access public and provenance if unscoped and unpublished',
   async t => {
     const { release, stubs } = setup({
@@ -393,7 +393,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should not override access restricted with provenance while unscoped and unpublished',
   async t => {
     const { release, stubs } = setup({
@@ -427,7 +427,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should publish with provenance and not add access when scoped and unpublished',
   async t => {
     const { release, stubs } = setup({
@@ -458,7 +458,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should publish with provenance and not add access when unscoped and published',
   async t => {
     const { release, stubs } = setup({
@@ -489,7 +489,7 @@ tap.test(
   }
 )
 
-tap.test('Should not publish to npm if there is no npm token', async () => {
+test('Should not publish to npm if there is no npm token', async () => {
   const { release, stubs } = setup()
   stubs.callApiStub.throws()
 
@@ -505,7 +505,7 @@ tap.test('Should not publish to npm if there is no npm token', async () => {
   sinon.assert.notCalled(stubs.publishToNpmStub)
 })
 
-tap.test('Should publish to npm with optic', async () => {
+test('Should publish to npm with optic', async () => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -523,7 +523,7 @@ tap.test('Should publish to npm with optic', async () => {
   })
 })
 
-tap.test('Should tag versions', async () => {
+test('Should tag versions', async () => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -540,7 +540,7 @@ tap.test('Should tag versions', async () => {
   sinon.assert.calledWithExactly(stubs.tagVersionStub, 'v5.1.3')
 })
 
-tap.test('Should call the release method', async () => {
+test('Should call the release method', async () => {
   const { release, stubs } = setup()
   await release({
     ...DEFAULT_ACTION_DATA,
@@ -572,7 +572,7 @@ tap.test('Should call the release method', async () => {
   )
 })
 
-tap.test(
+test(
   'Should call the release method with the prerelease flag if the release is a prerelease',
   async () => {
     const { release, stubs } = setup()
@@ -617,7 +617,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   "Should NOT call the release method if the pr wasn't merged",
   async () => {
     const { release, stubs } = setup()
@@ -635,7 +635,7 @@ tap.test(
   }
 )
 
-tap.test("Should NOT use npm if the pr wasn't merged", async () => {
+test("Should NOT use npm if the pr wasn't merged", async () => {
   const { release, stubs } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.context.payload.pull_request.merged = false
@@ -649,7 +649,7 @@ tap.test("Should NOT use npm if the pr wasn't merged", async () => {
   sinon.assert.notCalled(stubs.publishToNpmStub)
 })
 
-tap.test("Should NOT tag version in git if the pr wasn't merged", async () => {
+test("Should NOT tag version in git if the pr wasn't merged", async () => {
   const { release, stubs } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.context.payload.pull_request.merged = false
@@ -663,7 +663,7 @@ tap.test("Should NOT tag version in git if the pr wasn't merged", async () => {
   sinon.assert.notCalled(stubs.tagVersionStub)
 })
 
-tap.test(
+test(
   'Should not do anything if the user is not optic-release-automation[bot]',
   async () => {
     const { release, stubs } = setup()
@@ -676,7 +676,7 @@ tap.test(
   }
 )
 
-tap.test('Should fail if the release metadata is incorrect', async () => {
+test('Should fail if the release metadata is incorrect', async () => {
   const { release, stubs } = setup()
   const data = clone(DEFAULT_ACTION_DATA)
   data.context.payload.pull_request.body = 'this data is not correct'
@@ -687,7 +687,7 @@ tap.test('Should fail if the release metadata is incorrect', async () => {
   sinon.assert.notCalled(stubs.execWithOutputStub)
 })
 
-tap.test(
+test(
   'Should call core.setFailed if the tagging the version in git fails',
   async () => {
     const { release, stubs } = setup()
@@ -707,7 +707,7 @@ tap.test(
   }
 )
 
-tap.test('Should call core.setFailed if the release fails', async () => {
+test('Should call core.setFailed if the release fails', async () => {
   const { release, stubs } = setup()
   stubs.callApiStub.throws()
 
@@ -726,7 +726,7 @@ tap.test('Should call core.setFailed if the release fails', async () => {
   sinon.assert.calledOnce(stubs.coreStub.setFailed)
 })
 
-tap.test(
+test(
   'Should call core.setFailed but not revert the commit when publish to npm fails',
   async () => {
     const { release, stubs } = setup()
@@ -747,7 +747,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should call core.setFailed and revert the commit when publish to npm fails',
   async () => {
     const { release, stubs } = setup()
@@ -769,7 +769,7 @@ tap.test(
   }
 )
 
-tap.test('Should tag the major, minor & patch correctly for 0', async () => {
+test('Should tag the major, minor & patch correctly for 0', async () => {
   const { release, stubs } = setup()
   stubs.callApiStub.throws()
 
@@ -792,7 +792,7 @@ tap.test('Should tag the major, minor & patch correctly for 0', async () => {
   sinon.assert.calledWithExactly(stubs.tagVersionStub, 'v0.0.1')
 })
 
-tap.test('Should tag the major, minor & patch correctly', async () => {
+test('Should tag the major, minor & patch correctly', async () => {
   const { release, stubs } = setup()
   stubs.callApiStub.throws()
 
@@ -815,7 +815,7 @@ tap.test('Should tag the major, minor & patch correctly', async () => {
   sinon.assert.calledWithExactly(stubs.tagVersionStub, 'v5.0.0')
 })
 
-tap.test(
+test(
   'Should delete the release branch ALWAYS when the PR is closed',
   async () => {
     const { release, stubs } = setup()
@@ -840,7 +840,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should NOT delete the release branch if the PR is not closed',
   async () => {
     const { release, stubs } = setup()
@@ -865,7 +865,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should call notifyIssues function correctly when feature is enabled',
   async () => {
     const { release, stubs } = setup()
@@ -889,7 +889,7 @@ tap.test(
   }
 )
 
-tap.test(
+test(
   'Should not call notifyIssues function when feature is disabled',
   async () => {
     const { release, stubs } = setup()
@@ -906,7 +906,7 @@ tap.test(
   }
 )
 
-tap.test('Should not reject when notifyIssues fails', async t => {
+test('Should not reject when notifyIssues fails', async t => {
   const { release, stubs } = setup()
 
   stubs.notifyIssuesStub.rejects()
@@ -923,7 +923,7 @@ tap.test('Should not reject when notifyIssues fails', async t => {
   )
 })
 
-tap.test('Should fail when getting draft release fails', async () => {
+test('Should fail when getting draft release fails', async () => {
   const { release, stubs } = setup()
 
   await release({
@@ -943,7 +943,7 @@ tap.test('Should fail when getting draft release fails', async () => {
   sinon.assert.called(stubs.coreStub.setFailed)
 })
 
-tap.test('Should fail when release is not found', async () => {
+test('Should fail when release is not found', async () => {
   const { release, stubs } = setup()
 
   await release({
@@ -966,7 +966,7 @@ tap.test('Should fail when release is not found', async () => {
   )
 })
 
-tap.test('Should not fail when release is not a draft', async () => {
+test('Should not fail when release is not a draft', async () => {
   const { release, stubs } = setup()
 
   await release({

--- a/test/releaseNotes.test.js
+++ b/test/releaseNotes.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const assert = require('assert')
 const _template = require('lodash.template')
 const fs = require('fs')
 const path = require('path')
@@ -40,7 +41,7 @@ test('Should return the correct PR numbers', async t => {
   const result = getPrNumbersFromReleaseNotes(testReleaseNotes)
   const expected = ['13', '15', '16', '18', '42', '50', '52', '53']
 
-  t.same(result, expected)
+  assert.deepStrictEqual(result, expected)
 })
 
 test('Should return truncated PR body', async t => {
@@ -77,7 +78,7 @@ test('Should return truncated PR body', async t => {
     longPrBody = longPrBody + testReleaseNotes
   }
 
-  t.ok(longPrBody.length > 60000)
+  assert.ok(longPrBody.length > 60000)
 
   const truncatedPrBody = getPRBody(_template(tpl), {
     newVersion: '1.0.0',
@@ -86,8 +87,8 @@ test('Should return truncated PR body', async t => {
     author: 'test',
     artifact: null,
   })
-  t.ok(truncatedPrBody.length < 65536)
-  t.ok(
+  assert.ok(truncatedPrBody.length < 65536)
+  assert.ok(
     truncatedPrBody.includes(
       `<release-meta>{"id":1,"version":"1.0.0"}</release-meta>`
     )

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const tap = require('tap')
+const { test, mock } = require('node:test')
+const assert = require('assert')
 const sinon = require('sinon')
 const actionLog = require('../src/log')
 
@@ -9,7 +10,7 @@ const TAG = 'v1.0.1'
 
 const setup = ({ throwsError }) => {
   const logStub = sinon.stub(actionLog)
-  const releasesModule = tap.mock('../src/utils/releases.js', {
+  const releasesModule = mock('../src/utils/releases.js', {
     '../src/log.js': logStub,
     '@actions/github': {
       context: {
@@ -57,50 +58,50 @@ const setup = ({ throwsError }) => {
   return { logStub, releasesModule }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('fetchLatestRelease return properly the latest release', async t => {
+test('fetchLatestRelease return properly the latest release', async () => {
   const { releasesModule } = setup({ throwsError: false })
 
-  await t.resolves(releasesModule.fetchLatestRelease(TOKEN))
+  await assert.doesNotReject(releasesModule.fetchLatestRelease(TOKEN))
 })
 
-tap.test(
+test(
   'fetchLatestRelease throws an error if an exception occurs while calling GitHub APIs',
-  async t => {
+  async () => {
     const { releasesModule } = setup({ throwsError: true })
 
-    await t.rejects(releasesModule.fetchLatestRelease(TOKEN))
+    await assert.rejects(releasesModule.fetchLatestRelease(TOKEN))
   }
 )
 
-tap.test(
+test(
   'generateReleaseNotes return properly the generated release notes',
-  async t => {
+  async () => {
     const { releasesModule } = setup({ throwsError: false })
 
-    await t.resolves(
+    await assert.doesNotReject(
       releasesModule.generateReleaseNotes(TOKEN, '1.1.0', '1.0.0')
     )
   }
 )
 
-tap.test(
+test(
   'generateReleaseNotes throws an error if an exception occurs while calling GitHub APIs',
-  async t => {
+  async () => {
     const { releasesModule } = setup({ throwsError: true })
 
-    await t.rejects(releasesModule.generateReleaseNotes(TOKEN))
+    await assert.rejects(releasesModule.generateReleaseNotes(TOKEN))
   }
 )
 
-tap.test(
+test(
   'fetchLatestRelease returns null if no previous releases are found',
-  async t => {
+  async () => {
     const logStub = sinon.stub(actionLog)
-    const releasesModule = tap.mock('../src/utils/releases.js', {
+    const releasesModule = mock('../src/utils/releases.js', {
       '../src/log.js': logStub,
       '@actions/github': {
         context: {
@@ -121,28 +122,28 @@ tap.test(
       },
     })
 
-    await t.resolves(releasesModule.fetchLatestRelease(TOKEN))
+    await assert.doesNotReject(releasesModule.fetchLatestRelease(TOKEN))
   }
 )
 
-tap.test('fetchReleaseByTag return properly the specified release', async t => {
+test('fetchReleaseByTag return properly the specified release', async () => {
   const { releasesModule } = setup({ throwsError: false })
 
-  await t.resolves(releasesModule.fetchReleaseByTag(TOKEN, TAG))
+  await assert.doesNotReject(releasesModule.fetchReleaseByTag(TOKEN, TAG))
 })
 
-tap.test(
+test(
   'fetchReleaseByTag throws an error if an exception occurs while calling GitHub APIs',
-  async t => {
+  async () => {
     const { releasesModule } = setup({ throwsError: true })
 
-    await t.rejects(releasesModule.fetchReleaseByTag(TOKEN, TAG))
+    await assert.rejects(releasesModule.fetchReleaseByTag(TOKEN, TAG))
   }
 )
 
-tap.test('fetchReleaseByTag throws an error if Not Found', async t => {
+test('fetchReleaseByTag throws an error if Not Found', async () => {
   const logStub = sinon.stub(actionLog)
-  const releasesModule = tap.mock('../src/utils/releases.js', {
+  const releasesModule = mock('../src/utils/releases.js', {
     '../src/log.js': logStub,
     '@actions/github': {
       context: {
@@ -163,5 +164,5 @@ tap.test('fetchReleaseByTag throws an error if Not Found', async t => {
     },
   })
 
-  await t.rejects(releasesModule.fetchReleaseByTag(TOKEN, TAG))
+  await assert.rejects(releasesModule.fetchReleaseByTag(TOKEN, TAG))
 })

--- a/test/revertCommit.test.js
+++ b/test/revertCommit.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const setup = () => {
   return { execWithOutputStub, revertCommitProxy }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Revert commit', async t => {
+test('Revert commit', async t => {
   const { revertCommitProxy, execWithOutputStub } = setup()
   const baseRef = 'master'
   await revertCommitProxy.revertCommit(baseRef)

--- a/test/tagVersion.test.js
+++ b/test/tagVersion.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -13,16 +13,16 @@ const setup = () => {
   return { execWithOutputStub, tagVersionProxy }
 }
 
-tap.afterEach(() => {
+test.afterEach(() => {
   sinon.restore()
 })
 
-tap.test('Tag version in git', async t => {
+test('Tag version in git', async () => {
   const { tagVersionProxy, execWithOutputStub } = setup()
   const version = 'v3.0.0'
   await tagVersionProxy.tagVersionInGit(version)
 
-  t.ok(execWithOutputStub.callCount === 2)
+  assert.strictEqual(execWithOutputStub.callCount, 2)
 
   sinon.assert.calledWithExactly(execWithOutputStub, 'git', [
     'tag',


### PR DESCRIPTION
Convert unit tests from `tap` to `node:test` in multiple test files.

* **test/archiver.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax
* **test/artifact.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax
* **test/bump.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax
* **test/callApi.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax
* **test/commitMessage.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax
* **test/execWithOutput.test.js**
  - Replace `tap` module with `node:test` module
  - Update test cases to use `node:test` syntax

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msgadi/optic-release-automation-action/pull/5?shareId=b656784e-e350-47bd-9bfc-b8a2e44341a7).